### PR TITLE
ft: spam log filter to reduce Kafka bloat on cheap-gas chains

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -129,9 +129,14 @@ func NewListener(c *cli.Context) (*listener.Listener, error) {
 	msgEncoder := getMessageEncoder()
 
 	l.Infow("Setup handler", "topic", topic)
+	handlerOpts := []listener.Option{listener.WithEventLogs(nil, nil)}
+	if spamThreshold := c.Int(spamLogThresholdFlag.Name); spamThreshold > 0 {
+		l.Infow("Spam log filter enabled", "threshold", spamThreshold)
+		handlerOpts = append(handlerOpts, listener.WithSpamLogThreshold(spamThreshold))
+	}
 	handler := listener.NewHandler(listener.HandlerConfig{BlockSlowWarningThreshold: blockSlowWarningThresholdFlag.Value},
 		l, topic, httpEVMClient, blockKeeper, publisher, msgEncoder,
-		listener.WithEventLogs(nil, nil))
+		handlerOpts...)
 
 	l.Infow("Setup listener")
 

--- a/internal/app/flags.go
+++ b/internal/app/flags.go
@@ -189,6 +189,12 @@ var (
 		Value:   24 * time.Hour, //nolint:gomnd
 		Usage:   "Expiration time for storing block into datastore. Default: 24h",
 	}
+	spamLogThresholdFlag = &cli.IntFlag{
+		Name:    "spam-log-threshold",
+		EnvVars: []string{"SPAM_LOG_THRESHOLD"},
+		Value:   0,
+		Usage:   "Drop all but the last log per (address, topic0) when count exceeds this threshold per block. 0 disables the filter.",
+	}
 )
 
 // NewSentryFlags returns flags to init sentry client.
@@ -230,6 +236,11 @@ func NewBlockKeeperFlags() []cli.Flag {
 	return []cli.Flag{maxNumBlocksFlag, blockExpirationFlag}
 }
 
+// NewListenerFlags returns miscellaneous listener flags.
+func NewListenerFlags() []cli.Flag {
+	return []cli.Flag{spamLogThresholdFlag}
+}
+
 // NewFlags returns all flags for the application.
 func NewFlags() []cli.Flag {
 	flags := []cli.Flag{
@@ -248,6 +259,7 @@ func NewFlags() []cli.Flag {
 	flags = append(flags, NewEncoderFlags()...)
 	flags = append(flags, NewPublisherFlags()...)
 	flags = append(flags, NewBlockKeeperFlags()...)
+	flags = append(flags, NewListenerFlags()...)
 
 	return flags
 }

--- a/pkg/encoder/protobuf.go
+++ b/pkg/encoder/protobuf.go
@@ -3,8 +3,9 @@ package encoder
 import (
 	"errors"
 
-	"github.com/KyberNetwork/evmlistener/protobuf/pb"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/KyberNetwork/evmlistener/protobuf/pb"
 )
 
 type ProtobufEncoder struct{}

--- a/pkg/encoder/protobuf_test.go
+++ b/pkg/encoder/protobuf_test.go
@@ -4,9 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/KyberNetwork/evmlistener/pkg/types"
 	"github.com/KyberNetwork/evmlistener/protobuf/pb"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProtobufEncoder(t *testing.T) {

--- a/pkg/listener/filter_option.go
+++ b/pkg/listener/filter_option.go
@@ -3,9 +3,10 @@ package listener
 type Option func(opt *FilterOption)
 
 type FilterOption struct {
-	filterContracts []string
-	filterTopics    [][]string
-	withLogs        bool
+	filterContracts  []string
+	filterTopics     [][]string
+	withLogs         bool
+	spamLogThreshold int
 }
 
 func WithEventLogs(contracts []string, topics [][]string) Option {
@@ -13,5 +14,13 @@ func WithEventLogs(contracts []string, topics [][]string) Option {
 		opt.withLogs = true
 		opt.filterContracts = contracts
 		opt.filterTopics = topics
+	}
+}
+
+// WithSpamLogThreshold enables dropping all but the last log per (address, topic0) pair when a
+// block contains more than threshold occurrences. 0 disables the filter.
+func WithSpamLogThreshold(threshold int) Option {
+	return func(opt *FilterOption) {
+		opt.spamLogThreshold = threshold
 	}
 }

--- a/pkg/listener/handler.go
+++ b/pkg/listener/handler.go
@@ -251,6 +251,12 @@ func (h *Handler) handleNewBlock(ctx context.Context, b types.Block) error {
 		newBlocks = []types.Block{b}
 	}
 
+	if h.option.spamLogThreshold > 0 {
+		for i := range newBlocks {
+			newBlocks[i].Logs = filterSpamLogs(newBlocks[i].Logs, h.option.spamLogThreshold)
+		}
+	}
+
 	log.Infow("Publish message to queue",
 		"topic", h.topic,
 		"numRevertedBlocks", len(revertedBlocks),

--- a/pkg/listener/handler.go
+++ b/pkg/listener/handler.go
@@ -255,6 +255,9 @@ func (h *Handler) handleNewBlock(ctx context.Context, b types.Block) error {
 		for i := range newBlocks {
 			newBlocks[i].Logs = filterSpamLogs(newBlocks[i].Logs, h.option.spamLogThreshold)
 		}
+		for i := range revertedBlocks {
+			revertedBlocks[i].Logs = filterSpamLogs(revertedBlocks[i].Logs, h.option.spamLogThreshold)
+		}
 	}
 
 	log.Infow("Publish message to queue",

--- a/pkg/listener/utils.go
+++ b/pkg/listener/utils.go
@@ -38,7 +38,11 @@ func filterSpamLogs(logs []types.Log, threshold int) []types.Log {
 		return k
 	}
 
-	counts := make(map[key]int, len(logs))
+	if len(logs) <= threshold {
+		return logs
+	}
+
+	counts := make(map[key]int)
 	for _, l := range logs {
 		counts[keyOf(l)]++
 	}

--- a/pkg/listener/utils.go
+++ b/pkg/listener/utils.go
@@ -19,6 +19,48 @@ const (
 	defaultRetryInterval = 500 * time.Millisecond
 )
 
+// filterSpamLogs drops all but the last log for any (address, topic0) pair that appears more than
+// threshold times in the slice. Order of surviving logs is preserved.
+func filterSpamLogs(logs []types.Log, threshold int) []types.Log {
+	type key struct{ addr, topic0 string }
+
+	counts := make(map[key]int, len(logs))
+	for _, l := range logs {
+		if len(l.Topics) == 0 {
+			continue
+		}
+		counts[key{l.Address, l.Topics[0]}]++
+	}
+
+	// For each over-threshold key, record the index of its last occurrence.
+	lastIdx := make(map[key]int)
+	for i, l := range logs {
+		if len(l.Topics) == 0 {
+			continue
+		}
+		k := key{l.Address, l.Topics[0]}
+		if counts[k] > threshold {
+			lastIdx[k] = i
+		}
+	}
+
+	if len(lastIdx) == 0 {
+		return logs
+	}
+
+	filtered := make([]types.Log, 0, len(logs))
+	for i, l := range logs {
+		if len(l.Topics) > 0 {
+			k := key{l.Address, l.Topics[0]}
+			if last, isSpam := lastIdx[k]; isSpam && i != last {
+				continue
+			}
+		}
+		filtered = append(filtered, l)
+	}
+	return filtered
+}
+
 // getLogsByBlockHash returns logs by block hash, retry up to 3 times.
 func getLogsByBlockHash(ctx context.Context, evmClient evmclient.IClient, hash string,
 	contracts []string, topics [][]string,

--- a/pkg/listener/utils.go
+++ b/pkg/listener/utils.go
@@ -19,26 +19,34 @@ const (
 	defaultRetryInterval = 500 * time.Millisecond
 )
 
-// filterSpamLogs drops all but the last log for any (address, topic0) pair that appears more than
-// threshold times in the slice. Order of surviving logs is preserved.
+// filterSpamLogs drops all but the last log for any spam key that appears more than threshold
+// times in the slice. The key is (address, topic0, topic1) for events with topics, or (address)
+// alone for anonymous events (no topics). This lets through Uniswap V4 / Balancer vault events
+// where topic1 carries the pool ID and differs per pool, while catching mass-transfer airdrops
+// (same from-address in topic1) and anonymous event spam. Order of surviving logs is preserved.
 func filterSpamLogs(logs []types.Log, threshold int) []types.Log {
-	type key struct{ addr, topic0 string }
+	type key struct{ addr, topic0, topic1 string }
+
+	keyOf := func(l types.Log) key {
+		k := key{addr: l.Address}
+		if len(l.Topics) > 0 {
+			k.topic0 = l.Topics[0]
+		}
+		if len(l.Topics) > 1 {
+			k.topic1 = l.Topics[1]
+		}
+		return k
+	}
 
 	counts := make(map[key]int, len(logs))
 	for _, l := range logs {
-		if len(l.Topics) == 0 {
-			continue
-		}
-		counts[key{l.Address, l.Topics[0]}]++
+		counts[keyOf(l)]++
 	}
 
 	// For each over-threshold key, record the index of its last occurrence.
 	lastIdx := make(map[key]int)
 	for i, l := range logs {
-		if len(l.Topics) == 0 {
-			continue
-		}
-		k := key{l.Address, l.Topics[0]}
+		k := keyOf(l)
 		if counts[k] > threshold {
 			lastIdx[k] = i
 		}
@@ -50,11 +58,8 @@ func filterSpamLogs(logs []types.Log, threshold int) []types.Log {
 
 	filtered := make([]types.Log, 0, len(logs))
 	for i, l := range logs {
-		if len(l.Topics) > 0 {
-			k := key{l.Address, l.Topics[0]}
-			if last, isSpam := lastIdx[k]; isSpam && i != last {
-				continue
-			}
+		if last, isSpam := lastIdx[keyOf(l)]; isSpam && i != last {
+			continue
 		}
 		filtered = append(filtered, l)
 	}

--- a/pkg/listener/utils_test.go
+++ b/pkg/listener/utils_test.go
@@ -1,0 +1,93 @@
+package listener
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KyberNetwork/evmlistener/pkg/types"
+)
+
+func makeLog(addr, topic0, topic1 string) types.Log {
+	l := types.Log{Address: addr}
+	if topic0 != "" {
+		l.Topics = append(l.Topics, topic0)
+	}
+	if topic1 != "" {
+		l.Topics = append(l.Topics, topic1)
+	}
+	return l
+}
+
+func TestFilterSpamLogs_BelowThreshold(t *testing.T) {
+	logs := []types.Log{
+		makeLog("0xA", "0xT0", "0xT1"),
+		makeLog("0xA", "0xT0", "0xT1"),
+	}
+	got := filterSpamLogs(logs, 3)
+	assert.Equal(t, logs, got)
+}
+
+func TestFilterSpamLogs_AboveThreshold_KeepsLast(t *testing.T) {
+	// 4 logs sharing the same (addr, topic0, topic1) key, threshold = 3.
+	logs := []types.Log{
+		makeLog("0xA", "0xT0", "0xT1"), // index 0 — dropped
+		makeLog("0xA", "0xT0", "0xT1"), // index 1 — dropped
+		makeLog("0xA", "0xT0", "0xT1"), // index 2 — dropped
+		makeLog("0xA", "0xT0", "0xT1"), // index 3 — kept (last)
+	}
+	got := filterSpamLogs(logs, 3)
+	assert.Len(t, got, 1)
+	assert.Equal(t, logs[3], got[0])
+}
+
+func TestFilterSpamLogs_DifferentTopic1_AllKept(t *testing.T) {
+	// Simulates Uniswap V4 / Balancer: same address+topic0, different pool ID in topic1.
+	logs := []types.Log{
+		makeLog("0xVault", "0xSwap", "0xPool1"),
+		makeLog("0xVault", "0xSwap", "0xPool2"),
+		makeLog("0xVault", "0xSwap", "0xPool3"),
+		makeLog("0xVault", "0xSwap", "0xPool4"),
+	}
+	got := filterSpamLogs(logs, 3)
+	assert.Equal(t, logs, got)
+}
+
+func TestFilterSpamLogs_AnonymousEvents_KeyedByAddress(t *testing.T) {
+	// 4 anonymous logs (no topics) from the same address, threshold = 3.
+	logs := []types.Log{
+		{Address: "0xSpam"}, // index 0 — dropped
+		{Address: "0xSpam"}, // index 1 — dropped
+		{Address: "0xSpam"}, // index 2 — dropped
+		{Address: "0xSpam"}, // index 3 — kept
+	}
+	got := filterSpamLogs(logs, 3)
+	assert.Len(t, got, 1)
+	assert.Equal(t, logs[3], got[0])
+}
+
+func TestFilterSpamLogs_AnonymousEvents_DifferentAddress_AllKept(t *testing.T) {
+	logs := []types.Log{
+		{Address: "0xA"},
+		{Address: "0xB"},
+		{Address: "0xC"},
+		{Address: "0xD"},
+	}
+	got := filterSpamLogs(logs, 3)
+	assert.Equal(t, logs, got)
+}
+
+func TestFilterSpamLogs_PreservesOrderAndNonSpam(t *testing.T) {
+	// Mix of spam and legitimate logs; verify order is preserved.
+	logs := []types.Log{
+		makeLog("0xSpam", "0xT0", "0xT1"),  // 0 — dropped
+		makeLog("0xLegit", "0xT0", "0xP1"), // 1 — kept (unique pool)
+		makeLog("0xSpam", "0xT0", "0xT1"),  // 2 — dropped
+		makeLog("0xLegit", "0xT0", "0xP2"), // 3 — kept (unique pool)
+		makeLog("0xSpam", "0xT0", "0xT1"),  // 4 — dropped
+		makeLog("0xLegit", "0xT0", "0xP3"), // 5 — kept (unique pool)
+		makeLog("0xSpam", "0xT0", "0xT1"),  // 6 — kept (last spam)
+	}
+	got := filterSpamLogs(logs, 3)
+	assert.Equal(t, []types.Log{logs[1], logs[3], logs[5], logs[6]}, got)
+}

--- a/pkg/redis/stream_test.go
+++ b/pkg/redis/stream_test.go
@@ -6,8 +6,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/KyberNetwork/evmlistener/pkg/encoder"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/KyberNetwork/evmlistener/pkg/encoder"
 )
 
 type StreamTestSuite struct {

--- a/pkg/types/log.go
+++ b/pkg/types/log.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/KyberNetwork/evmlistener/protobuf/pb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/KyberNetwork/evmlistener/protobuf/pb"
 )
 
 // Log contains log information.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -3,8 +3,9 @@ package types
 import (
 	"math/big"
 
-	"github.com/KyberNetwork/evmlistener/protobuf/pb"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/KyberNetwork/evmlistener/protobuf/pb"
 )
 
 // Header contains block header information.


### PR DESCRIPTION
## Summary
- Adds `SPAM_LOG_THRESHOLD` env var (int, `0` = disabled). When set, any spam key with more than that many logs per block is deduplicated down to its last occurrence before publishing to Kafka / storing to Redis.
- Motivated by Berachain blocks that carry hundreds or thousands of junk events per block from a handful of contracts.

## Spam key definition
The dedup key is chosen to let legitimate high-volume contracts (Uniswap V4, Balancer vault) through:

| Event type | Key |
|---|---|
| Anonymous (no topics) | `address` |
| Has topics | `(address, topic0, topic1)` |

**Why this works:**
- Mass-airdrop spam (`Transfer` × 1000): same `from` in topic1 → all share one key → deduplicated ✓
- Anonymous event spam (`0xbd78...` × 176/block across many txs): keyed on address alone → deduplicated ✓
- Uniswap V4 / Balancer swaps: topic1 = pool ID, differs per pool → distinct key per pool → all preserved ✓

## Usage
```
SPAM_LOG_THRESHOLD=128
```
Set to `0` (or omit) to leave existing behaviour unchanged.

## Test plan
- [ ] `go test ./pkg/listener/...` passes
- [ ] Deploy to a Berachain instance with `SPAM_LOG_THRESHOLD=128` and verify bloated blocks are trimmed in Kafka messages while swap events from known DEX vaults are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)